### PR TITLE
[feat] 게시글 검색 기능 구현

### DIFF
--- a/src/main/java/org/example/products/controller/ProductController.java
+++ b/src/main/java/org/example/products/controller/ProductController.java
@@ -88,4 +88,15 @@ public class ProductController {
                         .build()
         );
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> searchProducts(@RequestParam("keyword") String keyword) {
+        List<ProductResponse> products = productService.searchProductsByKeyword(keyword);
+        return ResponseEntity.ok(
+                CommonResponseEntity.<List<ProductResponse>>builder()
+                        .data(products)
+                        .response(SuccessResponseEnum.REQUEST_SUCCESS)
+                        .build()
+        );
+    }
 }

--- a/src/main/java/org/example/products/repository/ProductRepository.java
+++ b/src/main/java/org/example/products/repository/ProductRepository.java
@@ -28,4 +28,7 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
 
     @Query("SELECT p FROM ProductEntity p JOIN FETCH p.user WHERE p.productId = :productId")
     Optional<ProductEntity> findByIdWithUser(@Param("productId") Long productId);
+
+    List<ProductEntity> findByTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(String title, String description);
+
 }

--- a/src/main/java/org/example/products/service/ProductService.java
+++ b/src/main/java/org/example/products/service/ProductService.java
@@ -130,6 +130,20 @@ public class ProductService {
                 .build();
     }
 
+    public List<ProductResponse> searchProductsByKeyword(String keyword) {
+        List<ProductEntity> products = productRepository
+                .findByTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(keyword, keyword);
+
+        if (products.isEmpty()) {
+            throw new CustomException(ErrorResponseEnum.POST_NOT_FOUND);
+        }
+
+        return products.stream()
+                .map(this::toProductResponse)
+                .collect(Collectors.toList());
+    }
+
+
 }
 
 


### PR DESCRIPTION
## 1. 작업 내용

- 게시글 검색 API 구현
- 제목 또는 설명에 키워드가 포함된 게시글 검색
- 대소문자 구분 없이 검색 처리 ('IgnoreCase')
- 검색 결과가 없을 경우 'POST_NOT_FOUND' 예외 반환 처리
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/47e71c6b-b6c9-46c6-b2c7-065abf283451)
![image](https://github.com/user-attachments/assets/76c2b064-2146-45f5-aafd-3c39e2cfa820)

<br/>

## 3. 추가해야 할 기능

- 검색 결과 페이징 처리 (추후)
- 검색 정렬 조건 추가 고려(최신순 등)
- 카테고리별 검색 필터 추가 고려
<br/>

## 4. 기타

-  검색 결과 없음 처리 시 빈 리스트 대신 예외 처리 적용 (`CustomException`)
<br/>

## 5. 이슈 링크
 cammoa_backend #21 
