### PR TITLE
[feat] 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/org/example/common/ResponseEnum/ErrorResponseEnum.java
+++ b/src/main/java/org/example/common/ResponseEnum/ErrorResponseEnum.java
@@ -21,7 +21,7 @@ public enum ErrorResponseEnum implements Response {
 
     //사용자
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "해당 게시글에 대한 권한이 없습니다."),
     //게시글
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
     INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "마감일은 현재 시각보다 이후여야 합니다."),

--- a/src/main/java/org/example/products/controller/ProductController.java
+++ b/src/main/java/org/example/products/controller/ProductController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.common.CommonResponseEntity;
 import org.example.common.ResponseEnum.SuccessResponseEnum;
 import org.example.products.dto.request.ProductCreateRequest;
+import org.example.products.dto.request.ProductUpdateRequest;
 import org.example.products.dto.response.ProductDetailResponse;
 import org.example.products.dto.response.ProductResponse;
 import org.example.products.service.ProductService;
@@ -99,4 +100,20 @@ public class ProductController {
                         .build()
         );
     }
+
+    @PatchMapping("/{postId}")
+    public ResponseEntity<?> updatePost(@PathVariable Long postId,
+                                        @RequestBody ProductUpdateRequest request) {
+        Long mockUserId = 1L; // 추후 로그인 연동 시 교체 예정
+
+        ProductResponse response = productService.updateProduct(postId, request, mockUserId);
+
+        return ResponseEntity.ok(
+                CommonResponseEntity.<ProductResponse>builder()
+                        .data(response)
+                        .response(SuccessResponseEnum.REQUEST_SUCCESS)
+                        .build()
+        );
+    }
+
 }

--- a/src/main/java/org/example/products/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/org/example/products/dto/request/ProductUpdateRequest.java
@@ -1,0 +1,22 @@
+package org.example.products.dto.request;
+
+import lombok.Getter;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Future;
+import java.time.LocalDateTime;
+
+
+@Getter
+public class ProductUpdateRequest {
+
+    private String title;
+    private String category;
+    private String description;
+    @Positive
+    private Integer price;
+    @Future
+    private LocalDateTime deadline;
+    private String place;
+    private String image;
+
+}

--- a/src/main/java/org/example/products/service/ProductService.java
+++ b/src/main/java/org/example/products/service/ProductService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.common.ResponseEnum.ErrorResponseEnum;
 import org.example.exception.CustomException;
 import org.example.products.dto.request.ProductCreateRequest;
+import org.example.products.dto.request.ProductUpdateRequest;
 import org.example.products.dto.response.ProductDetailResponse;
 import org.example.products.dto.response.ProductResponse;
 import org.example.products.repository.entity.ProductEntity;
@@ -11,6 +12,8 @@ import org.example.products.repository.ProductRepository;
 import org.example.users.repository.UserRepository;
 import org.example.users.repository.entity.UserEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.time.LocalDateTime;
@@ -141,6 +144,25 @@ public class ProductService {
         return products.stream()
                 .map(this::toProductResponse)
                 .collect(Collectors.toList());
+    }
+    @Transactional
+    public ProductResponse updateProduct(Long postId, ProductUpdateRequest request, Long userId) {
+        ProductEntity product = productRepository.findByIdWithUser(postId)
+                .orElseThrow(() -> new CustomException(ErrorResponseEnum.POST_NOT_FOUND));
+
+        if (!product.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorResponseEnum.UNAUTHORIZED_ACCESS);
+        }
+
+        if (request.getTitle() != null) product.setTitle(request.getTitle());
+        if (request.getCategory() != null) product.setCategory(request.getCategory());
+        if (request.getDescription() != null) product.setDescription(request.getDescription());
+        if (request.getPrice() != null) product.setPrice(request.getPrice());
+        if (request.getDeadline() != null) product.setDeadline(request.getDeadline());
+        if (request.getPlace() != null) product.setPlace(request.getPlace());
+        if (request.getImage() != null) product.setImage(request.getImage());
+
+        return toProductResponse(product);
     }
 
 

--- a/src/main/java/org/example/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/security/config/SecurityConfig.java
@@ -23,6 +23,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/auth/signup/email/verify").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/**").permitAll() // 게시글 생성 허용
                         .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
+                        .requestMatchers(HttpMethod.PATCH, "/api/posts/**").permitAll() //게시글 수정 허용
+
 
                         .anyRequest().authenticated() // 그 외 요청은 인증 필요
                 );


### PR DESCRIPTION
## 1. 작업 내용

- 게시글 수정 API (`PATCH /api/posts/{postId}`) 구현
- 수정 가능한 항목: 제목, 설명, 가격, 마감기한, 거래장소, 이미지, 카테고리
- 작성자 본인만 게시글 수정 가능하도록 권한 체크 (`UNAUTHORIZED_ACCESS`)
- `ProductUpdateRequest` DTO 생성
- `ProductService.updateProduct()` 내 더티 체킹 + 유효성 검사 적용
- 예외 처리 추가
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/9f8d09e8-cb3b-4052-9344-e7186fb4c42d)
![image](https://github.com/user-attachments/assets/ee035a29-9d9a-4e35-be35-184b2b738c40)

<br/>

## 3. 추가해야 할 기능

- 로그인 연동 후 실제 인증 사용자 기반으로 userId 추출 처리
-  카테고리 필드 enum 적용 고려 (`Category` enum 도입으로 고정값 처리)
<br/>

## 4. 기타

- 현재는 `mockUserId = 1L`로 처리된 상태
- Spring Security 설정에서 PATCH 요청은 `permitAll()` 적용된 상태
<br/>

## 5. 이슈 링크
 cammoa_backend #22 
