### PR TITLE
[refactor] 사용자 기반 userId 추출처리 및 카테고리 enum 타입 변경

### DIFF
--- a/src/main/java/org/example/products/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/org/example/products/dto/request/ProductUpdateRequest.java
@@ -3,6 +3,8 @@ package org.example.products.dto.request;
 import lombok.Getter;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Future;
+import org.example.products.repository.entity.CategoryEnum;
+
 import java.time.LocalDateTime;
 
 
@@ -10,7 +12,7 @@ import java.time.LocalDateTime;
 public class ProductUpdateRequest {
 
     private String title;
-    private String category;
+    private CategoryEnum category;
     private String description;
     @Positive
     private Integer price;

--- a/src/main/java/org/example/products/repository/entity/CategoryEnum.java
+++ b/src/main/java/org/example/products/repository/entity/CategoryEnum.java
@@ -1,0 +1,34 @@
+package org.example.products.repository.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum CategoryEnum {
+    FOOD("식품"),
+    WATER_DRINK("생수·음료"),
+    LIVING("생활용품"),
+    STATIONERY("문구류"),
+    BEAUTY("화장품");
+
+    private final String displayName;
+
+    CategoryEnum(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @JsonCreator
+    public static CategoryEnum from(String value) {
+        for (CategoryEnum category : CategoryEnum.values()) {
+            if (category.displayName.equals(value)) { // 한글이랑 매칭
+                return category;
+            }
+            if (category.name().equalsIgnoreCase(value)) { // 영어(enum 이름)이랑 매칭
+                return category;
+            }
+        }
+        throw new IllegalArgumentException("Unknown category: " + value);
+    }
+}

--- a/src/main/java/org/example/products/repository/entity/ProductEntity.java
+++ b/src/main/java/org/example/products/repository/entity/ProductEntity.java
@@ -21,8 +21,9 @@ public class ProductEntity {
     @Column(nullable = false)
     private String title;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String category;
+    private CategoryEnum category;
 
     @Column(nullable = false)
     private String description;

--- a/src/main/java/org/example/products/service/ProductService.java
+++ b/src/main/java/org/example/products/service/ProductService.java
@@ -7,6 +7,7 @@ import org.example.products.dto.request.ProductCreateRequest;
 import org.example.products.dto.request.ProductUpdateRequest;
 import org.example.products.dto.response.ProductDetailResponse;
 import org.example.products.dto.response.ProductResponse;
+import org.example.products.repository.entity.CategoryEnum;
 import org.example.products.repository.entity.ProductEntity;
 import org.example.products.repository.ProductRepository;
 import org.example.users.repository.UserRepository;
@@ -43,7 +44,7 @@ public class ProductService {
         ProductEntity product = ProductEntity.builder()
                 .user(user)
                 .title(request.getTitle())
-                .category(request.getCategory())
+                .category(CategoryEnum.valueOf(request.getCategory()))
                 .description(request.getDescription())
                 .image(request.getImage())
                 .price(request.getPrice())
@@ -52,6 +53,7 @@ public class ProductService {
                 .place(request.getPlace())
                 .status(request.getStatus())
                 .maxParticipants(request.getMaxParticipants())
+                .currentParticipants(1)  // 생성 시 본인 자동 참여
                 .build();
 
         ProductEntity saved = productRepository.save(product);
@@ -95,7 +97,7 @@ public class ProductService {
         return ProductResponse.builder()
                 .productId(product.getProductId())
                 .title(product.getTitle())
-                .category(product.getCategory())
+                .category(product.getCategory().name())
                 .description(product.getDescription())
                 .image(product.getImage())
                 .price(product.getPrice())
@@ -119,7 +121,7 @@ public class ProductService {
                 .productId(product.getProductId())
                 .title(product.getTitle())
                 .description(product.getDescription())
-                .category(product.getCategory())
+                .category(product.getCategory().name())
                 .image(product.getImage())
                 .price(product.getPrice())
                 .deadline(product.getDeadline())

--- a/src/main/java/org/example/security/JwtTokenProvider.java
+++ b/src/main/java/org/example/security/JwtTokenProvider.java
@@ -35,7 +35,7 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public JwtToken generateToken(Authentication authentication) {
+    public JwtToken generateToken(Authentication authentication, Long userId) {
 
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
@@ -49,6 +49,7 @@ public class JwtTokenProvider {
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim(AUTHORIZATION_KEY, authorities)
+                .claim("userId", userId)  // userId 추가
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -120,4 +121,10 @@ public class JwtTokenProvider {
             return e.getClaims();
         }
     }
+
+    public Long getUserId(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("userId", Long.class);  //userId 가져오기
+    }
+
 }

--- a/src/main/java/org/example/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/security/config/SecurityConfig.java
@@ -34,12 +34,13 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.POST, "/api/auth/signup").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/posts").authenticated()
                         .anyRequest().authenticated())
                 //JWT 인증을 위하여 직접 구현한 필터 추가
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class
-                )
-                .build();
+                );
+                return http.build(); // 이렇게 수정하지 않으면 빌드 오류가 뜸..
     }
 
     @Bean

--- a/src/main/java/org/example/users/service/UserServiceImpl.java
+++ b/src/main/java/org/example/users/service/UserServiceImpl.java
@@ -123,7 +123,7 @@ public class UserServiceImpl implements UserService {
 
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
-        JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
+        JwtToken jwtToken = jwtTokenProvider.generateToken(authentication, user.getId());
 
         return jwtToken;
     }


### PR DESCRIPTION
## 1. 작업 내용

- 로그인한 사용자 정보 기반으로 userId를 추출하여 게시글 작성 및 수정 시 자동으로 설정되도록 변경
- 게시글 생성/수정 시 한글("생활용품") 또는 영어("LIVING") 모두 받을 수 있도록 CategoryEnum 매핑 로직 추가
<br/>

## 2. 이미지 첨부


![image](https://github.com/user-attachments/assets/7efe2801-2901-41f9-8900-c476e30af9fb)

![image](https://github.com/user-attachments/assets/ae88e8c2-a2ff-4662-bfb4-5ebf46013861)
<br/>

## 3. 추가해야 할 기능

-
<br/>

## 4. 기타

- 게시글 생성 시 currentParticipants를 1로 초기화하여 작성자가 자동으로 참여한 상태로 저장
- UserServiceImpl 파일에서 로그인 성공 시 userId를 accessToken에 포함시켜, 게시글 작성 시 사용자 식별이 가능하도록 수정
- JwtTokenProvider 파일에서 accessToken 생성 시 userId를 클레임에 추가하고 userId를 꺼낼 수 있도록 getUserId() 메서드 추가
<br/>

## 5. 이슈 링크
 cammoa_backend #26 
