### PR TITLE
[Feat]게시글 이미지 업로드

### DIFF
--- a/src/main/java/org/example/chat/controller/ChatController.java
+++ b/src/main/java/org/example/chat/controller/ChatController.java
@@ -3,7 +3,7 @@ package org.example.chat.controller;
 import lombok.AllArgsConstructor;
 import org.example.chat.dto.request.CreateChatRoomRequest;
 import org.example.chat.dto.response.CreateChatRoomResponse;
-import org.example.chat.dto.response.GetChatRoomsResponse;
+//import org.example.chat.dto.response.GetChatRoomsResponse;
 import org.example.chat.service.ChatService;
 import org.example.common.ResponseEnum.SuccessResponseEnum;
 import org.example.common.repository.entity.CommonResponseEntity;

--- a/src/main/java/org/example/chat/service/ChatServiceimpl.java
+++ b/src/main/java/org/example/chat/service/ChatServiceimpl.java
@@ -3,7 +3,7 @@ package org.example.chat.service;
 import lombok.AllArgsConstructor;
 import org.example.chat.dto.response.CreateChatRoomResponse;
 import org.example.chat.dto.request.ChatMessageRequest;
-import org.example.chat.dto.response.GetChatRoomsResponse;
+//import org.example.chat.dto.response.GetChatRoomsResponse;
 import org.example.chat.repository.*;
 import org.example.chat.repository.entity.ChatMessageEntity;
 import org.example.chat.repository.entity.ChatParticipantEntity;

--- a/src/main/java/org/example/common/ResponseEnum/SuccessResponseEnum.java
+++ b/src/main/java/org/example/common/ResponseEnum/SuccessResponseEnum.java
@@ -15,7 +15,9 @@ public enum SuccessResponseEnum implements Response {
 
     EMAIL_SEND_SUCCESS(HttpStatus.OK, "Email Successfully Sent"),
     EMAIL_VERIFICATION_SUCCESS(HttpStatus.OK, "Email Verification Successed"),
-    REQUEST_SUCCESS(HttpStatus.OK, "Request Processed Successfully");
+    REQUEST_SUCCESS(HttpStatus.OK, "Request Processed Successfully"),
+
+    POST_DELETE_SUCCESS(HttpStatus.OK, "Post Deleted Successfully");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/example/products/controller/ProductController.java
+++ b/src/main/java/org/example/products/controller/ProductController.java
@@ -131,4 +131,19 @@ public class ProductController {
         );
     }
 
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<?> deletePost(@PathVariable Long postId,
+                                        @RequestHeader("Authorization") String authorizationHeader) {
+        String token = authorizationHeader.replace("Bearer ", "");
+        Long userId = jwtTokenProvider.getUserId(token);
+        productService.deleteProduct(postId, userId);
+
+        return ResponseEntity.ok(
+                CommonResponseEntity.builder()
+                        .response(SuccessResponseEnum.POST_DELETE_SUCCESS)
+                        .build()
+        );
+    }
+
+
 }

--- a/src/main/java/org/example/products/controller/ProductImageController.java
+++ b/src/main/java/org/example/products/controller/ProductImageController.java
@@ -1,0 +1,41 @@
+package org.example.products.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.common.repository.entity.CommonResponseEntity;
+import org.example.common.ResponseEnum.SuccessResponseEnum;
+import org.example.products.service.FileUploader;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+public class ProductImageController {
+
+    private final FileUploader fileUploadService;
+
+    @PostMapping("/{productId}/images")
+    public ResponseEntity<?> uploadImages(
+            @PathVariable Long productId,
+            @RequestParam("images") List<MultipartFile> images) throws IOException {
+
+        List<String> imageUrls = new ArrayList<>();
+
+        for (MultipartFile image : images) {
+            String url = fileUploadService.saveFile(image);
+            imageUrls.add(url);
+        }
+
+        return ResponseEntity.ok(
+                CommonResponseEntity.<List<String>>builder()
+                        .data(imageUrls)
+                        .response(SuccessResponseEnum.REQUEST_SUCCESS)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/org/example/products/repository/ProductRepository.java
+++ b/src/main/java/org/example/products/repository/ProductRepository.java
@@ -45,5 +45,9 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
             @Param("sortType") String sortType
     );
     List<ProductEntity> findByUser(UserEntity user);
+
+    @Query("SELECT p FROM ProductEntity p JOIN FETCH p.user WHERE p.productId = :postId AND p.deletedAt IS NULL")
+    Optional<ProductEntity> findByIdWithUserAndNotDeleted(@Param("postId") Long postId);
+
 }
 

--- a/src/main/java/org/example/products/repository/entity/ProductEntity.java
+++ b/src/main/java/org/example/products/repository/entity/ProductEntity.java
@@ -68,4 +68,6 @@ public class ProductEntity {
     @JoinColumn(name = "user_id")
     private UserEntity user;
 
+    private LocalDateTime deletedAt;
+
 }

--- a/src/main/java/org/example/products/service/FileUploader.java
+++ b/src/main/java/org/example/products/service/FileUploader.java
@@ -1,0 +1,9 @@
+package org.example.products.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface FileUploader {
+    String saveFile(MultipartFile file) throws IOException;
+}

--- a/src/main/java/org/example/products/service/LocalUploader.java
+++ b/src/main/java/org/example/products/service/LocalUploader.java
@@ -1,0 +1,30 @@
+package org.example.products.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.UUID;
+
+@Service
+@Profile("local") // 로컬 환경에서만 동작
+public class LocalUploader implements FileUploader {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public String saveFile(MultipartFile file) throws IOException {
+        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        Path filePath = Paths.get(uploadDir + File.separator + fileName);
+
+        Files.createDirectories(filePath.getParent());
+        Files.copy(file.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+
+        return "/images/" + fileName;
+    }
+}

--- a/src/main/java/org/example/products/service/ProductService.java
+++ b/src/main/java/org/example/products/service/ProductService.java
@@ -197,5 +197,17 @@ public class ProductService {
                 .build();
     }
 
+    @Transactional
+    public void deleteProduct(Long postId, Long userId) {
+        ProductEntity product = productRepository.findByIdWithUserAndNotDeleted(postId)
+                .orElseThrow(() -> new ResourceException(ErrorResponseEnum.POST_NOT_FOUND));
+
+        if (!product.getUser().getId().equals(userId)) {
+            throw new AuthException(ErrorResponseEnum.UNAUTHORIZED_ACCESS);
+        }
+
+        product.setDeletedAt(LocalDateTime.now());
+    }
+
 }
 

--- a/src/main/java/org/example/products/service/S3Uploader.java
+++ b/src/main/java/org/example/products/service/S3Uploader.java
@@ -1,0 +1,18 @@
+package org.example.products.service;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@Profile("!local") // 로컬 환경 제외, 배포 환경에서 사용
+public class S3Uploader implements FileUploader {
+
+    @Override
+    public String saveFile(MultipartFile file) throws IOException {
+        // S3 업로드 로직 (임시 구현)
+        return "https://s3-bucket-url/" + file.getOriginalFilename();
+    }
+}

--- a/src/main/java/org/example/security/config/WebConfig.java
+++ b/src/main/java/org/example/security/config/WebConfig.java
@@ -1,0 +1,19 @@
+package org.example.security.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:" + uploadDir);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,9 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET_KEY}
+
+profiles:
+  active: local
+
+file:
+  upload-dir: uploads/


### PR DESCRIPTION
## 1. 작업 내용

- 게시글 이미지 업로드 API 구현
- 단일 및 다중 이미지 업로드 모두 가능하도록 처리
- 업로드된 이미지를 정적으로 서빙하기 위한 webConfig 추가
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/0621e8c0-896c-45a6-9650-16e6baebc3f1)

<br/>

## 3. 추가해야 할 기능

- AWS 배포 시 파일 저장 로직을 S3 기반으로 전환 필요
<br/>

## 4. 기타

- 
<br/>

## 5. 이슈 링크
 cammoa_backend #46 
