### PR TITLE
[feat] 사용자 채팅방 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/example/chat/controller/ChatController.java
+++ b/src/main/java/org/example/chat/controller/ChatController.java
@@ -37,7 +37,7 @@ public class ChatController {
         return ResponseEntity.ok(
                 CommonResponseEntity.<List<GetChatRoomsResponse>>builder()
                         .data(chatRooms)
-                        .response(SuccessResponseEnum.RESOURCES_CREATED)
+                        .response(SuccessResponseEnum.RESOURCES_GET)
                         .build()
         );
     }

--- a/src/main/java/org/example/chat/controller/ChatController.java
+++ b/src/main/java/org/example/chat/controller/ChatController.java
@@ -10,6 +10,8 @@ import org.example.common.repository.entity.CommonResponseEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/chats")
 @AllArgsConstructor
@@ -28,4 +30,15 @@ public class ChatController {
         );
     }
 
+    //채팅 목록 조회
+    @GetMapping("/rooms/list")
+    public ResponseEntity<?> getChatRooms() {
+        List<GetChatRoomsResponse> chatRooms = chatService.getChatRooms();
+        return ResponseEntity.ok(
+                CommonResponseEntity.<GetChatRoomsResponse>builder()
+                        .data(chatRooms)
+                        .response(SuccessResponseEnum.RESOURCES_CREATED)
+                        .build()
+        );
+    }
 }

--- a/src/main/java/org/example/chat/controller/ChatController.java
+++ b/src/main/java/org/example/chat/controller/ChatController.java
@@ -35,7 +35,7 @@ public class ChatController {
     public ResponseEntity<?> getChatRooms() {
         List<GetChatRoomsResponse> chatRooms = chatService.getChatRooms();
         return ResponseEntity.ok(
-                CommonResponseEntity.<GetChatRoomsResponse>builder()
+                CommonResponseEntity.<List<GetChatRoomsResponse>>builder()
                         .data(chatRooms)
                         .response(SuccessResponseEnum.RESOURCES_CREATED)
                         .build()

--- a/src/main/java/org/example/chat/controller/ChatController.java
+++ b/src/main/java/org/example/chat/controller/ChatController.java
@@ -3,7 +3,7 @@ package org.example.chat.controller;
 import lombok.AllArgsConstructor;
 import org.example.chat.dto.request.CreateChatRoomRequest;
 import org.example.chat.dto.response.CreateChatRoomResponse;
-//import org.example.chat.dto.response.GetChatRoomsResponse;
+import org.example.chat.dto.response.GetChatRoomsResponse;
 import org.example.chat.service.ChatService;
 import org.example.common.ResponseEnum.SuccessResponseEnum;
 import org.example.common.repository.entity.CommonResponseEntity;

--- a/src/main/java/org/example/chat/dto/response/GetChatRoomsResponse.java
+++ b/src/main/java/org/example/chat/dto/response/GetChatRoomsResponse.java
@@ -1,0 +1,15 @@
+package org.example.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetChatRoomsResponse {
+    private Long roomId;
+    private String roomName;
+}

--- a/src/main/java/org/example/chat/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomJpaRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomEntity, Long> {
     ChatRoomEntity save(ChatRoomEntity chatRoom);
     Optional<ChatRoomEntity> findById(Long roomId);
+    Optional<ChatRoomEntity> findByUser(UserEntity user);
 }

--- a/src/main/java/org/example/chat/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomJpaRepository.java
@@ -4,10 +4,11 @@ import org.example.chat.repository.entity.ChatRoomEntity;
 import org.example.users.repository.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomEntity, Long> {
     ChatRoomEntity save(ChatRoomEntity chatRoom);
     Optional<ChatRoomEntity> findById(Long roomId);
-    Optional<ChatRoomEntity> findByUser(UserEntity user);
+    List<ChatRoomEntity> findByUser(UserEntity user);
 }

--- a/src/main/java/org/example/chat/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomJpaRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomEntity, Long> {
     ChatRoomEntity save(ChatRoomEntity chatRoom);
     Optional<ChatRoomEntity> findById(Long roomId);
-    List<ChatRoomEntity> findByUser(UserEntity user);
+    List<ChatRoomEntity> findByChatParticipantsUser(UserEntity user);
 }

--- a/src/main/java/org/example/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomRepository.java
@@ -3,10 +3,11 @@ package org.example.chat.repository;
 import org.example.chat.repository.entity.ChatRoomEntity;
 import org.example.users.repository.entity.UserEntity;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomRepository {
     ChatRoomEntity save(ChatRoomEntity chatRoom);
     Optional<ChatRoomEntity> findById(Long roomId);
-    Optional<ChatRoomEntity> findByUser(UserEntity user);
+    List<ChatRoomEntity> findByUser(UserEntity user);
 }

--- a/src/main/java/org/example/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomRepository.java
@@ -1,10 +1,12 @@
 package org.example.chat.repository;
 
 import org.example.chat.repository.entity.ChatRoomEntity;
+import org.example.users.repository.entity.UserEntity;
 
 import java.util.Optional;
 
 public interface ChatRoomRepository {
     ChatRoomEntity save(ChatRoomEntity chatRoom);
     Optional<ChatRoomEntity> findById(Long roomId);
+    Optional<ChatRoomEntity> findByUser(UserEntity user);
 }

--- a/src/main/java/org/example/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface ChatRoomRepository {
     ChatRoomEntity save(ChatRoomEntity chatRoom);
     Optional<ChatRoomEntity> findById(Long roomId);
-    List<ChatRoomEntity> findByUser(UserEntity user);
+    List<ChatRoomEntity> findByChatParticipantsUser(UserEntity user);
 }

--- a/src/main/java/org/example/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomRepositoryImpl.java
@@ -6,6 +6,7 @@ import org.example.chat.repository.entity.ChatRoomEntity;
 import org.example.users.repository.entity.UserEntity;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -21,5 +22,5 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
     public Optional<ChatRoomEntity> findById(Long roomId){return chatRoomJpaRepository.findById(roomId);}
 
     @Override
-    public Optional<ChatRoomEntity> findByUser(UserEntity user){return chatRoomJpaRepository.findByUser(user);}
+    public List<ChatRoomEntity> findByUser(UserEntity user){return chatRoomJpaRepository.findByUser(user);}
 }

--- a/src/main/java/org/example/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.example.chat.repository;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.example.chat.repository.entity.ChatRoomEntity;
+import org.example.users.repository.entity.UserEntity;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -18,4 +19,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
 
     @Override
     public Optional<ChatRoomEntity> findById(Long roomId){return chatRoomJpaRepository.findById(roomId);}
+
+    @Override
+    public Optional<ChatRoomEntity> findByUser(UserEntity user){return chatRoomJpaRepository.findByUser(user);}
 }

--- a/src/main/java/org/example/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.example.chat.repository;
 
 import lombok.AllArgsConstructor;
 import org.example.chat.repository.entity.ChatRoomEntity;
+import org.example.products.repository.entity.ProductEntity;
 import org.example.users.repository.entity.UserEntity;
 import org.springframework.stereotype.Repository;
 
@@ -21,5 +22,5 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
     public Optional<ChatRoomEntity> findById(Long roomId){return chatRoomJpaRepository.findById(roomId);}
 
     @Override
-    public List<ChatRoomEntity> findByUser(UserEntity user){return chatRoomJpaRepository.findByUser(user);}
+    public List<ChatRoomEntity> findByChatParticipantsUser(UserEntity user){return chatRoomJpaRepository.findByChatParticipantsUser(user);}
 }

--- a/src/main/java/org/example/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/org/example/chat/repository/ChatRoomRepositoryImpl.java
@@ -1,6 +1,5 @@
 package org.example.chat.repository;
 
-import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.example.chat.repository.entity.ChatRoomEntity;
 import org.example.users.repository.entity.UserEntity;

--- a/src/main/java/org/example/chat/service/ChatService.java
+++ b/src/main/java/org/example/chat/service/ChatService.java
@@ -2,8 +2,12 @@ package org.example.chat.service;
 
 import org.example.chat.dto.response.CreateChatRoomResponse;
 import org.example.chat.dto.request.ChatMessageRequest;
+import org.example.chat.dto.response.GetChatRoomsResponse;
+
+import java.util.List;
 
 public interface ChatService {
     void saveMessage(Long roomId, ChatMessageRequest request);
     CreateChatRoomResponse createChatRoom(Long productId, String chatRoomName);
+    List<GetChatRoomsResponse> getChatRooms();
 }

--- a/src/main/java/org/example/chat/service/ChatServiceimpl.java
+++ b/src/main/java/org/example/chat/service/ChatServiceimpl.java
@@ -3,7 +3,7 @@ package org.example.chat.service;
 import lombok.AllArgsConstructor;
 import org.example.chat.dto.response.CreateChatRoomResponse;
 import org.example.chat.dto.request.ChatMessageRequest;
-//import org.example.chat.dto.response.GetChatRoomsResponse;
+import org.example.chat.dto.response.GetChatRoomsResponse;
 import org.example.chat.repository.*;
 import org.example.chat.repository.entity.ChatMessageEntity;
 import org.example.chat.repository.entity.ChatParticipantEntity;
@@ -21,6 +21,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.example.common.ResponseEnum.ErrorResponseEnum.POST_NOT_FOUND;
@@ -98,7 +99,17 @@ public class ChatServiceimpl implements ChatService {
         UserEntity user = userRepository.findByUsername(SecurityContextHolder.getContext().getAuthentication().getName())
                 .orElseThrow(() -> new AuthException(ErrorResponseEnum.USER_NOT_FOUND));
 
-        List<GetChatRoomsResponse> response = chatRoomRepository.findByUser(user);
+        List<ChatRoomEntity> chatRooms = chatRoomRepository.findByUser(user);
 
+        List<GetChatRoomsResponse> getChatRooms = new ArrayList<>();
+        for(ChatRoomEntity c: chatRooms) {
+            GetChatRoomsResponse getChatRoom = GetChatRoomsResponse
+                    .builder()
+                    .roomId(c.getChatRoomId())
+                    .roomName(c.getChatRoomName())
+                    .build();
+            getChatRooms.add(getChatRoom);
+        }
+        return getChatRooms;
     }
 }

--- a/src/main/java/org/example/chat/service/ChatServiceimpl.java
+++ b/src/main/java/org/example/chat/service/ChatServiceimpl.java
@@ -94,4 +94,11 @@ public class ChatServiceimpl implements ChatService {
         return new CreateChatRoomResponse(chatRoom.getChatRoomId(), chatRoom.getChatRoomName());
     }
 
+    public List<GetChatRoomsResponse> getChatRooms(){
+        UserEntity user = userRepository.findByUsername(SecurityContextHolder.getContext().getAuthentication().getName())
+                .orElseThrow(() -> new AuthException(ErrorResponseEnum.USER_NOT_FOUND));
+
+        List<GetChatRoomsResponse> response = chatRoomRepository.findByUser(user);
+
+    }
 }

--- a/src/main/java/org/example/chat/service/ChatServiceimpl.java
+++ b/src/main/java/org/example/chat/service/ChatServiceimpl.java
@@ -99,7 +99,7 @@ public class ChatServiceimpl implements ChatService {
         UserEntity user = userRepository.findByUsername(SecurityContextHolder.getContext().getAuthentication().getName())
                 .orElseThrow(() -> new AuthException(ErrorResponseEnum.USER_NOT_FOUND));
 
-        List<ChatRoomEntity> chatRooms = chatRoomRepository.findByUser(user);
+        List<ChatRoomEntity> chatRooms = chatRoomRepository.findByChatParticipantsUser(user);
 
         List<GetChatRoomsResponse> getChatRooms = new ArrayList<>();
         for(ChatRoomEntity c: chatRooms) {

--- a/src/main/java/org/example/common/ResponseEnum/SuccessResponseEnum.java
+++ b/src/main/java/org/example/common/ResponseEnum/SuccessResponseEnum.java
@@ -15,9 +15,13 @@ public enum SuccessResponseEnum implements Response {
 
     EMAIL_SEND_SUCCESS(HttpStatus.OK, "Email Successfully Sent"),
     EMAIL_VERIFICATION_SUCCESS(HttpStatus.OK, "Email Verification Successed"),
+
     REQUEST_SUCCESS(HttpStatus.OK, "Request Processed Successfully"),
 
+    RESOURCES_GET(HttpStatus.OK, "Resourses Is Got Successfully"),
     POST_DELETE_SUCCESS(HttpStatus.OK, "Post Deleted Successfully");
+
+
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 1. 작업 내용

- 로그인한 사용자의 채팅방 목록 조회 기능 구현

<br/>

## 2. 이미지 첨부
<img src="https://github.com/user-attachments/assets/a58b54d9-f9e9-4720-a36a-70663622d390" width="50%" height="50%">
<br/>

## 3. 추가해야 할 기능

- 로그인 리팩토링 후 사용자 조회 정보 통일
<br/>

## 4. 기타

- 
<br/>

## 5. 이슈 링크
 cammoa_backend #42 
