### PR TITLE
[feat] 공동구매 참여 상태 확인

### DIFF
--- a/src/main/java/org/example/products/controller/ParticipationController.java
+++ b/src/main/java/org/example/products/controller/ParticipationController.java
@@ -5,10 +5,14 @@ import lombok.RequiredArgsConstructor;
 import org.example.common.ResponseEnum.SuccessResponseEnum;
 import org.example.common.repository.entity.CommonResponseEntity;
 import org.example.products.dto.request.GroupBuyingJoinRequest;
+import org.example.products.service.ParticipationService;
 import org.example.products.service.ProductService;
 import org.example.security.JwtTokenProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/group-buyings")
@@ -17,6 +21,7 @@ public class ParticipationController {
 
     private final ProductService productService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final ParticipationService participationService;
 
     @PostMapping("/join")
     public ResponseEntity<?> joinGroupBuying(@RequestBody @Valid GroupBuyingJoinRequest request,
@@ -31,5 +36,25 @@ public class ParticipationController {
                         .response(SuccessResponseEnum.JOIN_SUCCESS)
                         .build()
         );
+    }
+
+    @GetMapping("/{group_buy_id}/status")
+    public ResponseEntity<?> checkParticipationStatus(@PathVariable("group_buy_id") Long postId,
+                                                      @RequestHeader("Authorization") String authorizationHeader) {
+        String token = authorizationHeader.replace("Bearer ", "");
+        Long userId = jwtTokenProvider.getUserId(token);
+
+        boolean isJoined = participationService.checkParticipationStatus(postId, userId);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("isJoined", isJoined);
+
+        return ResponseEntity.ok(
+                CommonResponseEntity.<Map<String, Object>>builder()
+                        .response(SuccessResponseEnum.JOIN_SUCCESS) // 또는 별도의 응답 메시지 enum 추가
+                        .data(response)
+                        .build()
+        );
+
     }
 }

--- a/src/main/java/org/example/products/service/ParticipationService.java
+++ b/src/main/java/org/example/products/service/ParticipationService.java
@@ -1,0 +1,31 @@
+package org.example.products.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.common.ResponseEnum.ErrorResponseEnum;
+import org.example.exception.impl.ResourceException;
+import org.example.products.repository.ParticipationRepository;
+import org.example.products.repository.ProductRepository;
+import org.example.products.repository.entity.ProductEntity;
+import org.example.users.repository.UserRepository;
+import org.example.users.repository.entity.UserEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipationService {
+
+    private final ProductRepository productRepository;
+    private final ParticipationRepository participationRepository;
+    private final UserRepository userRepository;
+
+    public boolean checkParticipationStatus(Long postId, Long userId) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceException(ErrorResponseEnum.USER_NOT_FOUND));
+
+        ProductEntity product = productRepository.findById(postId)
+                .orElseThrow(() -> new ResourceException(ErrorResponseEnum.POST_NOT_FOUND));
+
+        return participationRepository.existsByUserAndProduct(user, product);
+    }
+
+}


### PR DESCRIPTION
## 1. 작업 내용

- 공동구매 참여 상태 확인 api 구현
- 사용자가 해당 게시글에 참여중인지 여부를 반환
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/259e880c-6e06-4b72-8af5-a1248d553ba5)

<br/>

## 3. 추가해야 할 기능

- 참여 취소 api
<br/>

## 4. 기타

- 
<br/>

## 5. 이슈 링크
 cammoa_backend #55 
