### PR TITLE
[refactor] 게시글목록조회 리팩토링

### DIFF
--- a/src/main/java/org/example/common/ResponseEnum/ErrorResponseEnum.java
+++ b/src/main/java/org/example/common/ResponseEnum/ErrorResponseEnum.java
@@ -29,7 +29,7 @@ public enum ErrorResponseEnum implements Response {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "Post not found"),
     INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "Deadline must be after the current time"),
     INVALID_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "Max participants must be greater than current participants"),
-
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "Invalid category"),
     //중복된 리소스
     DUPLICATED_USERNAME(HttpStatus.CONFLICT , "Duplicated username"),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT , "Duplicated email"),

--- a/src/main/java/org/example/products/controller/ProductController.java
+++ b/src/main/java/org/example/products/controller/ProductController.java
@@ -3,12 +3,14 @@ package org.example.products.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.chat.dto.response.JoinChatRoomResponse;
+import org.example.common.ResponseEnum.ErrorResponseEnum;
 import org.example.common.ResponseEnum.SuccessResponseEnum;
 import org.example.common.repository.entity.CommonResponseEntity;
 import org.example.products.constant.SortTypeEnum;
 import org.example.products.dto.request.ProductCreateRequest;
 import org.example.products.dto.request.ProductUpdateRequest;
 import org.example.products.dto.response.ProductDetailResponse;
+import org.example.products.dto.response.ProductListResponse;
 import org.example.products.dto.response.ProductResponse;
 import org.example.products.repository.entity.CategoryEnum;
 import org.example.products.service.ProductService;
@@ -42,10 +44,23 @@ public class ProductController {
     }
     //게시글 목록 조회
     @GetMapping
-    public ResponseEntity<?> getAllProducts() {
-        List<ProductResponse> responseList = productService.getAllProducts();
+    public ResponseEntity<?> getAllProducts(@RequestParam(value = "category", required = false) String categoryStr) {
+        CategoryEnum category = null;
+        if (categoryStr != null && !categoryStr.isBlank()) {
+            try {
+                category = CategoryEnum.from(categoryStr);
+            } catch (IllegalArgumentException e) {
+                return ResponseEntity.badRequest().body(
+                        CommonResponseEntity.builder()
+                                .response(ErrorResponseEnum.INVALID_REQUEST)
+                                .build()
+                );
+            }
+        }
+        List<ProductListResponse> responseList = productService.getAllProductsByCategory(category);
+
         return ResponseEntity.ok(
-                CommonResponseEntity.<List<ProductResponse>>builder()
+                CommonResponseEntity.<List<ProductListResponse>>builder()
                         .data(responseList)
                         .response(SuccessResponseEnum.REQUEST_SUCCESS)
                         .build()
@@ -54,9 +69,9 @@ public class ProductController {
 
     @GetMapping("/recommend")
     public ResponseEntity<?> getRecommendedProducts() {
-        List<ProductResponse> products = productService.getRecommendedProducts();
+        List<ProductListResponse> products = productService.getRecommendedProducts();
         return ResponseEntity.ok(
-                CommonResponseEntity.<List<ProductResponse>>builder()
+                CommonResponseEntity.<List<ProductListResponse>>builder()
                         .data(products)
                         .response(SuccessResponseEnum.REQUEST_SUCCESS)
                         .build()
@@ -65,9 +80,9 @@ public class ProductController {
 
     @GetMapping("/closing-soon")
     public ResponseEntity<?> getClosingSoonProducts() {
-        List<ProductResponse> products = productService.getClosingSoonProducts();
+        List<ProductListResponse> products = productService.getClosingSoonProducts();
         return ResponseEntity.ok(
-                CommonResponseEntity.<List<ProductResponse>>builder()
+                CommonResponseEntity.<List<ProductListResponse>>builder()
                         .data(products)
                         .response(SuccessResponseEnum.REQUEST_SUCCESS)
                         .build()
@@ -76,9 +91,9 @@ public class ProductController {
 
     @GetMapping("/recent")
     public ResponseEntity<?> getRecentlyPostedProducts() {
-        List<ProductResponse> products = productService.getRecentlyPostedProducts();
+        List<ProductListResponse> products = productService.getRecentlyPostedProducts();
         return ResponseEntity.ok(
-                CommonResponseEntity.<List<ProductResponse>>builder()
+                CommonResponseEntity.<List<ProductListResponse>>builder()
                         .data(products)
                         .response(SuccessResponseEnum.REQUEST_SUCCESS)
                         .build()

--- a/src/main/java/org/example/products/dto/request/ProductCreateRequest.java
+++ b/src/main/java/org/example/products/dto/request/ProductCreateRequest.java
@@ -6,13 +6,14 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.example.products.repository.entity.CategoryEnum;
 
 @Getter
 public class ProductCreateRequest {
     @NotBlank
     private String title;
-    @NotBlank
-    private String category;
+    @NotNull
+    private CategoryEnum category;
     @NotBlank
     private String description;
     @NotBlank

--- a/src/main/java/org/example/products/dto/response/ProductListResponse.java
+++ b/src/main/java/org/example/products/dto/response/ProductListResponse.java
@@ -1,0 +1,25 @@
+package org.example.products.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.products.repository.entity.ProductEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ProductListResponse {
+    private Long id;
+    private String title;
+    private int price;
+    private String imageUrl;
+
+    public static ProductListResponse from(ProductEntity product) {
+        return ProductListResponse.builder()
+                .id(product.getProductId())
+                .title(product.getTitle())
+                .price(product.getPrice())
+                .imageUrl(product.getImage())
+                .build();
+    }
+}

--- a/src/main/java/org/example/products/repository/ProductRepository.java
+++ b/src/main/java/org/example/products/repository/ProductRepository.java
@@ -48,5 +48,7 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
     @Query("SELECT p FROM ProductEntity p JOIN FETCH p.user WHERE p.productId = :postId AND p.deletedAt IS NULL")
     Optional<ProductEntity> findByIdWithUserAndNotDeleted(@Param("postId") Long postId);
 
+    List<ProductEntity> findByCategory(CategoryEnum category);
+
 }
 

--- a/src/main/java/org/example/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/security/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.example.security.JwtTokenProvider;
 import org.example.security.filter.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,7 +31,9 @@ public class SecurityConfig {
                 //JWT를 사용하기 때문에 세션 사용 X
                 .sessionManagement(httpSecuritySessionManagementConfigurer -> httpSecuritySessionManagementConfigurer
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(a -> a.requestMatchers("/api/auth/signup", "/api/auth/login", "/connect").permitAll()
+                .authorizeHttpRequests(a -> a
+                        .requestMatchers("/api/auth/signup", "/api/auth/login", "/connect").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll() //게시글 목록 조회, 상세페이지, 검색 기능 로그인 없이 접근 가능하도록 수정
                         .anyRequest().authenticated())
                 //JWT 인증을 위하여 직접 구현한 필터 추가
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),


### PR DESCRIPTION
## 1. 작업 내용

- 게시글 목록 조회 API 응답 형식을 ProductListResponse로 변경하여 간결화
- 추천순, 마감순, 최신순 api에서도 동일하게 간단한 응답 형식 적용
- 게시글 목록 조회 시 카테고리 필터링 기능 적용
- 로그인 없이 게시글 목록, 상세, 검색 페이지 접근 가능하도록 수정
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/ad928409-e90c-4100-b5bd-fd77e5ae5b45)

<br/>

## 3. 추가해야 할 기능

-
<br/>

## 4. 기타

- 
<br/>

## 5. 이슈 링크
 cammoa_backend #60 
