### PR TITLE
[feat] 공구인원 모집 완료 시 이메일 알림 전송 기능 구현

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -14,5 +14,19 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="0@localhost" uuid="de8de7a1-4942-4b43-8b3f-56eeb00c5b1a">
+      <driver-ref>redis</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <remarks>$PROJECT_DIR$/src/main/resources/application.yml</remarks>
+      <jdbc-driver>jdbc.RedisDriver</jdbc-driver>
+      <jdbc-url>jdbc:redis://localhost:6379/0</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/src/main/java/org/example/common/ResponseEnum/ErrorResponseEnum.java
+++ b/src/main/java/org/example/common/ResponseEnum/ErrorResponseEnum.java
@@ -42,8 +42,10 @@ public enum ErrorResponseEnum implements Response {
     ALREADY_JOINED(HttpStatus.BAD_REQUEST, "You have already joined this group buying."),
     POST_CLOSED(HttpStatus.BAD_REQUEST, "This group buying is already closed."),
     POST_FULL(HttpStatus.BAD_REQUEST, "This group buying has reached the maximum number of participants."),
-    NOT_JOINED(HttpStatus.BAD_REQUEST, "You have not joined this group buying and cannot cancel participation.");
+    NOT_JOINED(HttpStatus.BAD_REQUEST, "You have not joined this group buying and cannot cancel participation."),
 
+    //알림
+    POST_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "Group buying is not yet completed");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/org/example/common/ResponseEnum/SuccessResponseEnum.java
+++ b/src/main/java/org/example/common/ResponseEnum/SuccessResponseEnum.java
@@ -24,7 +24,9 @@ public enum SuccessResponseEnum implements Response {
     //공동구매 참여
     JOIN_SUCCESS(HttpStatus.OK, "You have successfully joined the group buying."),
     CHATROOM_JOIN_SUCCESS(HttpStatus.OK, "Joined The Chat Room Successfully"),
-    CANCEL_SUCCESS(HttpStatus.OK, "Successfully canceled group buying participation.");
+    CANCEL_SUCCESS(HttpStatus.OK, "Successfully canceled group buying participation."),
+    //알림 전송
+    EMAIL_NOTIFICATION_SENT(HttpStatus.OK, "Completion email notification has been sent.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/example/email/service/EmailService.java
+++ b/src/main/java/org/example/email/service/EmailService.java
@@ -3,9 +3,14 @@ package org.example.email.service;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.example.email.dto.response.SendEmailResponse;
+import org.example.products.repository.entity.ProductEntity;
+import org.example.users.repository.entity.UserEntity;
+
+import java.util.List;
 
 public interface EmailService {
     String createCode();
     MimeMessage createMail(String mail, String authCode) throws MessagingException;
     String sendSimpleMessage(String sendEmail) throws MessagingException;
+    void sendCompletionNotification(ProductEntity product, List<UserEntity> participants);
 }

--- a/src/main/java/org/example/email/service/EmailServiceImpl.java
+++ b/src/main/java/org/example/email/service/EmailServiceImpl.java
@@ -6,13 +6,17 @@ import lombok.RequiredArgsConstructor;
 import org.example.common.ResponseEnum.ErrorResponseEnum;
 import org.example.email.dto.response.SendEmailResponse;
 import org.example.exception.impl.AuthException;
+import org.example.products.repository.entity.ParticipationEntity;
+import org.example.products.repository.entity.ProductEntity;
 import org.example.redis.RedisUtil;
+import org.example.users.repository.entity.UserEntity;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -76,4 +80,26 @@ public class EmailServiceImpl implements EmailService{
             throw new AuthException(ErrorResponseEnum.EMAIL_SEND_FAILED);
         }
     }
+
+    @Override
+    public void sendCompletionNotification(ProductEntity product, List<UserEntity> participants) {
+        for (UserEntity user : participants) {
+            try {
+                MimeMessage message = javaMailSender.createMimeMessage();
+                message.setFrom(senderEmail);
+                message.setRecipients(MimeMessage.RecipientType.TO, user.getEmail());
+                message.setSubject("[모집 완료] '" + product.getTitle() + "' 공동구매 모집이 완료되었습니다!");
+
+                String body = "<h3>참여하신 공동구매가 모집 완료되었습니다.</h3>"
+                        + "<p>상품명: <strong>" + product.getTitle() + "</strong></p>"
+                        + "<p>마감일: " + product.getDeadline() + "</p>";
+
+                message.setText(body, "UTF-8", "html");
+                javaMailSender.send(message);
+            } catch (MessagingException e) {
+                System.err.println("이메일 전송 실패: " + user.getEmail());
+            }
+        }
+    }
+
 }

--- a/src/main/java/org/example/products/controller/ParticipationController.java
+++ b/src/main/java/org/example/products/controller/ParticipationController.java
@@ -74,4 +74,18 @@ public class ParticipationController {
         );
     }
 
+    // 공동구매 모집 완료 이메일 알림 전송
+    @PostMapping("/{group_buy_id}/notify")
+    public ResponseEntity<?> notifyGroupBuyingCompletion(@PathVariable("group_buy_id") Long postId) {
+
+        productService.notifyGroupBuyingCompletion(postId);
+
+        return ResponseEntity.ok(
+                CommonResponseEntity.builder()
+                        .response(SuccessResponseEnum.EMAIL_NOTIFICATION_SENT)
+                        .build()
+        );
+    }
+
+
 }

--- a/src/main/java/org/example/products/repository/ParticipationRepository.java
+++ b/src/main/java/org/example/products/repository/ParticipationRepository.java
@@ -12,5 +12,6 @@ public interface ParticipationRepository extends JpaRepository<ParticipationEnti
     boolean existsByUserAndProduct(UserEntity user, ProductEntity product);
     Optional<ParticipationEntity> findByUserAndProduct(UserEntity user, ProductEntity product);
     List<ParticipationEntity> findAllByUser(UserEntity user);
+    List<ParticipationEntity> findAllByProduct(ProductEntity product);
 
 }


### PR DESCRIPTION
## 1. 작업 내용

- /api/group-buyings/{group_buy_id}/notify 이메일 알림 API 구현
- 모집 인원 모집 완료 시 참여자 전원에게 모집 완료 메일 전송
- 예외 상황 처리 (POST_NOT_FOUND, POST_NOT_COMPLETED)
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/e61b853b-47b0-4009-8a1f-1120259adb21)

![Screenshot_20250512_170034_Gmail](https://github.com/user-attachments/assets/39e5b0d7-1c25-4c20-85d8-f1c8138efc89)


<br/>

## 3. 추가해야 할 기능

-
<br/>

## 4. 기타

- 
<br/>

## 5. 이슈 링크
 cammoa_backend #64 
