### PR TITLE
Refactor/게시글상세페이지수정/#114

### DIFF
--- a/src/main/java/org/example/products/controller/ProductImageController.java
+++ b/src/main/java/org/example/products/controller/ProductImageController.java
@@ -37,7 +37,8 @@ public class ProductImageController {
 
         List<String> imageUrls = new ArrayList<>();
 
-        for (MultipartFile image : images) {
+        for (int i = 0; i < images.size(); i++) {
+            MultipartFile image = images.get(i);
             String url = fileUploadService.saveFile(image);
             imageUrls.add(url);
 
@@ -46,6 +47,11 @@ public class ProductImageController {
                     .imageUrl(url)
                     .build();
             productImageRepository.save(imageEntity);
+
+            if (i == 0) {
+                product.setImage(url); // ← ProductEntity.image 필드에 대표 이미지 설정
+                productRepository.save(product);
+            }
         }
 
         return ResponseEntity.ok(

--- a/src/main/java/org/example/products/dto/response/ProductDetailResponse.java
+++ b/src/main/java/org/example/products/dto/response/ProductDetailResponse.java
@@ -13,7 +13,7 @@ public class ProductDetailResponse {
     private String title;
     private String description;
     private String category;
-    private List<String> imageUrls;
+    private List<String> imageUrl;
     private Integer price;
     private LocalDateTime deadline;
     private String place;

--- a/src/main/java/org/example/products/dto/response/ProductDetailResponse.java
+++ b/src/main/java/org/example/products/dto/response/ProductDetailResponse.java
@@ -13,7 +13,7 @@ public class ProductDetailResponse {
     private String title;
     private String description;
     private String category;
-    private String imageUrl;
+    private List<String> imageUrls;
     private Integer price;
     private LocalDateTime deadline;
     private String place;

--- a/src/main/java/org/example/products/repository/ProductImageRepository.java
+++ b/src/main/java/org/example/products/repository/ProductImageRepository.java
@@ -1,0 +1,13 @@
+package org.example.products.repository;
+
+import org.example.products.repository.entity.ProductEntity;
+import org.example.products.repository.entity.ProductImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductImageRepository extends JpaRepository<ProductImageEntity, Long> {
+
+    // 특정 게시글에 연관된 모든 이미지 조회
+    List<ProductImageEntity> findAllByProduct(ProductEntity product);
+}

--- a/src/main/java/org/example/products/repository/entity/ProductEntity.java
+++ b/src/main/java/org/example/products/repository/entity/ProductEntity.java
@@ -5,6 +5,8 @@ import lombok.*;
 import org.example.users.repository.entity.UserEntity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -69,5 +71,10 @@ public class ProductEntity {
     private UserEntity user;
 
     private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductImageEntity> images = new ArrayList<>();
+
+
 
 }

--- a/src/main/java/org/example/products/repository/entity/ProductImageEntity.java
+++ b/src/main/java/org/example/products/repository/entity/ProductImageEntity.java
@@ -1,0 +1,24 @@
+package org.example.products.repository.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductImageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private ProductEntity product;
+
+    @Column(nullable = false)
+    private String imageUrl;
+}

--- a/src/main/java/org/example/products/service/ProductService.java
+++ b/src/main/java/org/example/products/service/ProductService.java
@@ -202,7 +202,7 @@ public class ProductService {
                 .title(product.getTitle())
                 .description(product.getDescription())
                 .category(product.getCategory().name())
-                .imageUrls(imageUrls)
+                .imageUrl(imageUrls)
                 .price(product.getPrice())
                 .deadline(product.getDeadline())
                 .place(product.getPlace())

--- a/src/main/java/org/example/products/service/ProductService.java
+++ b/src/main/java/org/example/products/service/ProductService.java
@@ -17,10 +17,12 @@ import org.example.products.dto.request.ProductCreateRequest;
 import org.example.products.dto.request.ProductUpdateRequest;
 import org.example.products.dto.response.*;
 import org.example.products.repository.ParticipationRepository;
+import org.example.products.repository.ProductImageRepository;
 import org.example.products.repository.ProductRepository;
 import org.example.products.repository.entity.CategoryEnum;
 import org.example.products.repository.entity.ParticipationEntity;
 import org.example.products.repository.entity.ProductEntity;
+import org.example.products.repository.entity.ProductImageEntity;
 import org.example.users.repository.UserRepository;
 import org.example.users.repository.entity.UserEntity;
 import org.springframework.data.domain.PageRequest;
@@ -45,6 +47,7 @@ public class ProductService {
     private final ChatParticipantRepository chatParticipantRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final EmailService emailService;
+    private final ProductImageRepository productImageRepository;
 
     public ProductResponse createProduct(ProductCreateRequest request, Long userId) {
 
@@ -172,6 +175,11 @@ public class ProductService {
         ProductEntity product = productRepository.findByIdWithUser(productId)
                 .orElseThrow(() -> new ResourceException(ErrorResponseEnum.POST_NOT_FOUND)); // 예외처리
 
+        //게시글의 모든 이미지 URL 조회
+        List<String> imageUrls = productImageRepository.findAllByProduct(product).stream()
+                .map(ProductImageEntity::getImageUrl)
+                .toList();
+
         // 작성자 본인의 다른 게시글 중 현재 게시글 제외하고 6개 랜덤 추출
         List<ProductSimpleResponse> relatedPosts = productRepository.findByUser(product.getUser()).stream()
                 .filter(p -> !p.getProductId().equals(product.getProductId()))
@@ -194,7 +202,7 @@ public class ProductService {
                 .title(product.getTitle())
                 .description(product.getDescription())
                 .category(product.getCategory().name())
-                .imageUrl(product.getImage())
+                .imageUrls(imageUrls)
                 .price(product.getPrice())
                 .deadline(product.getDeadline())
                 .place(product.getPlace())


### PR DESCRIPTION
## 1. 작업 내용

-  게시글 상세 응답에서 이미지 관련 필드를 imageUrl: List<String>로 단일화
- 상세 페이지 응답 시 여러 이미지가 imageUrl 배열로 전달되도록 수정
- ProductService.getProductDetail()에서 productImageRepository를 통해 이미지 리스트 조회하여 설정
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/b91e2f76-689b-4c06-a18d-3dff7f1202b6)

<br/>

## 3. 추가해야 할 기능

-
<br/>

## 4. 기타

- 
<br/>

## 5. 이슈 링크
 cammoa_backend #114 
