### PR TITLE
[refactor] 게시글 검색 시 카테고리만 선택한 경우 그에 해당하는 게시글 목록 반환

### DIFF
--- a/src/main/java/org/example/products/controller/ProductController.java
+++ b/src/main/java/org/example/products/controller/ProductController.java
@@ -112,7 +112,7 @@ public class ProductController {
     }
     //게시글 검색
     @GetMapping("/search")
-    public ResponseEntity<?> searchProducts(@RequestParam("keyword") String keyword, @RequestParam(value = "category", required = false) String category, @RequestParam(value = "sortTypeEnum", defaultValue = "DEADLINE") SortTypeEnum sortTypeEnum) {
+    public ResponseEntity<?> searchProducts(@RequestParam(value = "keyword", required = false) String keyword, @RequestParam(value = "category", required = false) String category, @RequestParam(value = "sortTypeEnum", defaultValue = "DEADLINE") SortTypeEnum sortTypeEnum) {
 
         CategoryEnum categoryEnum = null;
         if (category != null && !category.isBlank()) {


### PR DESCRIPTION
## 1. 작업 내용

- 제곧내...
- 카테고리만 선택 후 검색을 하면 그 카테고리에 해당하는 목록들 반환
- 키워드만 검색 시 마찬가지로 키워드가 들어간 목록들 반환됨
- 둘 다 선택도 가능
- 마감기한을 기준으로 정렬됨
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/9871d1e6-26d5-453b-8baf-0d3df24ab72a)

<br/>

## 3. 추가해야 할 기능

-
<br/>

## 4. 기타

- 
<br/>

## 5. 이슈 링크
 cammoa_backend #116 
