### PR TITLE
Refactor/게시글삭제및목록수정/#131

### DIFF
--- a/src/main/java/org/example/common/ResponseEnum/ErrorResponseEnum.java
+++ b/src/main/java/org/example/common/ResponseEnum/ErrorResponseEnum.java
@@ -36,6 +36,7 @@ public enum ErrorResponseEnum implements Response {
     INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "Deadline must be after the current time"),
     INVALID_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "Max participants must be greater than current participants"),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "Invalid category"),
+    POST_HAS_PARTICIPANTS(HttpStatus.BAD_REQUEST, "Cannot delete the post because other users have already joined"),
 
     //중복된 리소스
     DUPLICATED_USERNAME(HttpStatus.CONFLICT , "Duplicated username"),

--- a/src/main/java/org/example/products/repository/ParticipationRepository.java
+++ b/src/main/java/org/example/products/repository/ParticipationRepository.java
@@ -13,5 +13,6 @@ public interface ParticipationRepository extends JpaRepository<ParticipationEnti
     Optional<ParticipationEntity> findByUserAndProduct(UserEntity user, ProductEntity product);
     List<ParticipationEntity> findAllByUser(UserEntity user);
     List<ParticipationEntity> findAllByProduct(ProductEntity product);
+    int countByProduct(ProductEntity product);
 
 }

--- a/src/main/java/org/example/products/repository/ProductRepository.java
+++ b/src/main/java/org/example/products/repository/ProductRepository.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
 
     // 오늘의 공동구매 추천: DB에서 랜덤으로 가져옴
-    @Query(value = "SELECT * FROM product_entity WHERE deleted_at IS NULL ORDER BY RAND() LIMIT 8", nativeQuery = true)
+    @Query(value = "SELECT * FROM product_entity WHERE deleted_at IS NULL AND deadline >= CURRENT_DATE ORDER BY RAND() LIMIT 8", nativeQuery = true)
     List<ProductEntity> findRandomRecommendedProducts();
 
     // 곧 마감되는 공구: 마감일이 오늘 이후인 공구 중 마감일이 가까운 순
@@ -26,12 +26,13 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long> {
     Page<ProductEntity> findClosingSoonProducts(Pageable pageable);
 
     // 방금 올라온 공구
-    @Query("SELECT p FROM ProductEntity p WHERE p.deletedAt IS NULL ORDER BY p.createdAt DESC")
+    @Query("SELECT p FROM ProductEntity p WHERE p.deletedAt IS NULL AND p.deadline >= CURRENT_DATE ORDER BY p.createdAt DESC")
     Page<ProductEntity> findRecentProducts(Pageable pageable);
 
     //게시글 검식 시 카테고리, 추천, 최신, 마감순 조회
     @Query("SELECT p FROM ProductEntity p " +
             "WHERE p.deletedAt IS NULL " +
+            "AND p.deadline >= CURRENT_DATE " +
             "AND (:keyword IS NULL OR :keyword = '' OR p.title LIKE %:keyword% OR p.description LIKE %:keyword%) " +
             "AND (:category IS NULL OR p.category = :category) " +
             "ORDER BY " +

--- a/src/main/java/org/example/products/service/ProductService.java
+++ b/src/main/java/org/example/products/service/ProductService.java
@@ -307,7 +307,14 @@ public class ProductService {
         if (!product.getUser().getId().equals(userId)) {
             throw new AuthException(ErrorResponseEnum.UNAUTHORIZED_ACCESS);
         }
+        //본인 외 다른 참여자가 존재하는지 확인
+        List<ParticipationEntity> participants = participationRepository.findAllByProduct(product);
+        boolean hasOtherParticipants = participants.stream()
+                .anyMatch(p -> !p.getUser().getId().equals(userId));
 
+        if (hasOtherParticipants) {
+            throw new CustomException(ErrorResponseEnum.POST_HAS_PARTICIPANTS);
+        }
         product.setDeletedAt(LocalDateTime.now());
     }
 


### PR DESCRIPTION
## 1. 작업 내용

- 마감기한 지난 게시글 목록 및 검색에 뜨지 않도록 수정
- 게시글 삭제 시 다른 참여자가 존재하면 삭제 불가하도록 수정
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/24f21e10-a3e4-431e-8c0e-4375ab761f15)

<br/>

## 3. 추가해야 할 기능

-
<br/>

## 4. 기타

- 
<br/>

## 5. 이슈 링크
 cammoa_backend #131 
