### PR TITLE
[refactor] 게시글 목록 마감기한 지난 목록 필터링 수정

### DIFF
--- a/src/main/java/org/example/products/service/ProductService.java
+++ b/src/main/java/org/example/products/service/ProductService.java
@@ -112,7 +112,10 @@ public class ProductService {
             products = productRepository.findByDeletedAtIsNull();
         }
 
+        LocalDateTime now = LocalDateTime.now();
+
         return products.stream()
+                .filter(p -> p.getDeadline() == null || p.getDeadline().isAfter(now))
                 .map(product -> ProductListResponse.builder()
                         .id(product.getProductId())
                         .title(product.getTitle())
@@ -126,7 +129,9 @@ public class ProductService {
 
     // 오늘의 공동구매 추천 (랜덤 8개)
     public List<ProductListResponse> getRecommendedProducts() {
+        LocalDateTime now = LocalDateTime.now();
         return productRepository.findRandomRecommendedProducts().stream()
+                .filter(p -> p.getDeadline() == null || p.getDeadline().isAfter(now))
                 .map(ProductListResponse::from)
                 .collect(Collectors.toList());
     }
@@ -134,9 +139,11 @@ public class ProductService {
     // 곧 마감되는 공구 (마감일 빠른 순 4개)
     public List<ProductListResponse> getClosingSoonProducts() {
         Pageable limit4 = PageRequest.of(0, 4);
+        LocalDateTime now = LocalDateTime.now();
         return productRepository.findClosingSoonProducts(limit4)
                 .getContent()
                 .stream()
+                .filter(p -> p.getDeadline() == null || p.getDeadline().isAfter(now))
                 .map(ProductListResponse::from)
                 .collect(Collectors.toList());
     }
@@ -144,9 +151,11 @@ public class ProductService {
     // 방금 올라온 공구 (생성일 최신순 4개)
     public List<ProductListResponse> getRecentlyPostedProducts() {
         Pageable limit4 = PageRequest.of(0, 4);
+        LocalDateTime now = LocalDateTime.now();
         return productRepository.findRecentProducts(limit4)
                 .getContent()
                 .stream()
+                .filter(p -> p.getDeadline() == null || p.getDeadline().isAfter(now))
                 .map(ProductListResponse::from)
                 .collect(Collectors.toList());
     }
@@ -253,6 +262,11 @@ public class ProductService {
         // keyword가 없는 경우
         if (keyword == null || keyword.isBlank()) {
             products = productRepository.findByCategoryAndNotDeletedAndNotExpired(category);
+
+            LocalDateTime now = LocalDateTime.now();
+            products = products.stream()
+                    .filter(p -> p.getDeadline() == null || p.getDeadline().isAfter(now))
+                    .collect(Collectors.toList());
 
             // 정렬
             if (sortTypeEnum == SortTypeEnum.DEADLINE) {


### PR DESCRIPTION
## 1. 작업 내용

- 게시글 목록에서 마감기한 지난 게시글 필터링하여 조회되지 않도록 재수정
<br/>

## 2. 이미지 첨부

![image](https://github.com/user-attachments/assets/1b4ab36e-d1be-44d6-a611-437ea21f057a)

<br/>

## 3. 추가해야 할 기능

-
<br/>

## 4. 기타

- 
<br/>

## 5. 이슈 링크
 cammoa_backend #131 
